### PR TITLE
Enable reverse order for legend. Set by default

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -1,6 +1,6 @@
 ol.control.LayerSwitcher = function(opt_options) {
 
-    var options = this.options = opt_options || { reverse: true};
+    var options = opt_options || {};
 
     var hiddenClassName = 'ol-unselectable ol-control layer-switcher';
     this.hiddenClassName = hiddenClassName;
@@ -67,14 +67,6 @@ function forEachRecursive(lyr, fn) {
     });
 }
 
-function reverseArray(input) {
-    var ret = new Array;
-    for(var i = input.length-1; i >= 0; i--) {
-        ret.push(input[i]);
-    }
-    return ret;
-}
-
 ol.control.LayerSwitcher.prototype.setState = function(map, lyr) {
     lyr.setVisible(!lyr.getVisible());
     if (lyr.get('type') === 'base') {
@@ -104,10 +96,7 @@ ol.control.LayerSwitcher.prototype.renderLayer = function(lyr, idx) {
         var ul = document.createElement('ul');
         li.appendChild(ul);
 
-        var arrayLegend = lyr.getLayers().getArray();
-        if (this.options.reverse) {
-            arrayLegend = reverseArray(arrayLegend);
-        }
+        var arrayLegend = lyr.getLayers().getArray().slice().reverse();
 
         arrayLegend.forEach(function(lyr, idx, a) {
             ul.appendChild(this_.renderLayer(lyr, idx));
@@ -150,10 +139,7 @@ ol.control.LayerSwitcher.prototype.render = function(map) {
     var ul = document.createElement('ul');
     this.panel.appendChild(ul);
 
-    var arrayLegend = map.getLayers().getArray();
-    if (this.options.reverse) {
-        arrayLegend = reverseArray(arrayLegend);
-    }
+    var arrayLegend = map.getLayers().getArray().slice().reverse();
     
     arrayLegend.forEach(function(lyr, idx, a) {
         ul.appendChild(this_.renderLayer(lyr, idx));


### PR DESCRIPTION
In the layer list in the map layers, the first added elements are the one below the other layers. On the legend panel, this order is the same.
I would expect for legend the opposite : getting the 'base' layers below instead of being at the top.
I submit a patch to be able to choose to keep order or reverse it.
Ready to discuss
