### PR TITLE
Add possibility to change the interaction behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ See [the examples](./examples) for usage.
 |:---|:---|:----------|
 |`opt_options`|`Object`| Control options, extends olx.control.ControlOptions adding: **`tipLabel`** `String` - the button tooltip. |
 
+#### Options:
+
+|Name|Type|Description|Default|
+|:---|:---|:----------|:----------|
+|`tipLabel`|`String`| the button tooltip. | "Legend" |
+|`closeOnMouseOut`|`boolean`| should the menu panel close when the mouse is moved out of it? | `true` |
+|`openOnMouseOver`|`boolean`| should the menu panel open automatically when hovering over the switcher's icon? | `true` |
+
 #### Extends
 
 `ol.control.Control`

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -8,10 +8,13 @@
  */
 ol.control.LayerSwitcher = function(opt_options) {
 
-    var options = opt_options || {};
+    this.options = opt_options || {};
 
-    var tipLabel = options.tipLabel ?
-      options.tipLabel : 'Legend';
+    var tipLabel = this.options.tipLabel ?
+      this.options.tipLabel : 'Legend';
+    
+    this.options.closeOnMouseOut = this.options.closeOnMouseOut || true;
+    this.options.openOnMouseOver = this.options.openOnMouseOver || true;
 
     this.mapListeners = [];
 
@@ -35,31 +38,50 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     var this_ = this;
 
-    button.onmouseover = function(e) {
-        this_.showPanel();
+    button.onmouseover = function(e){
+    	this_.onButtonMouseOver(e);
     };
-
-    button.onclick = function(e) {
-        e = e || window.event;
-        this_.showPanel();
-        e.preventDefault();
+    
+    button.onclick = function(e){
+    	this_.onButtonClick(e);
     };
-
-    this_.panel.onmouseout = function(e) {
-        e = e || window.event;
-        if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
-            this_.hidePanel();
-        }
+    
+    this.panel.onmouseout = function(e){
+    	this_.onPanelMouseOut(e);
     };
 
     ol.control.Control.call(this, {
         element: element,
-        target: options.target
+        target: this.options.target
     });
 
 };
 
 ol.inherits(ol.control.LayerSwitcher, ol.control.Control);
+
+ol.control.LayerSwitcher.prototype.onButtonClick = function(e){
+	e = e || window.event;
+	
+	if (this.element.className != this.shownClassName) {
+		this.showPanel();
+	}else{
+		this.hidePanel();
+	}
+	e.preventDefault();
+};
+
+ol.control.LayerSwitcher.prototype.onButtonMouseOver = function(e){
+	if( this.options.openOnMouseOver ){
+		this.showPanel();
+	}
+};
+
+ol.control.LayerSwitcher.prototype.onPanelMouseOut = function(e) {
+	e = e || window.event;
+    if (this.options.closeOnMouseOut && ( !this.panel.contains(e.toElement || e.relatedTarget)) ) {
+        this.hidePanel();
+    }
+}; 
 
 /**
  * Show the layer panel.

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -59,6 +59,9 @@ ol.control.LayerSwitcher = function(opt_options) {
 
 ol.inherits(ol.control.LayerSwitcher, ol.control.Control);
 
+/**
+ * Event handler for clicks no the control button.
+ */
 ol.control.LayerSwitcher.prototype.onButtonClick = function(e){
 	e = e || window.event;
 	
@@ -70,12 +73,18 @@ ol.control.LayerSwitcher.prototype.onButtonClick = function(e){
 	e.preventDefault();
 };
 
+/**
+ * Event handler for mouseOver on the control button.
+ */
 ol.control.LayerSwitcher.prototype.onButtonMouseOver = function(e){
 	if( this.options.openOnMouseOver ){
 		this.showPanel();
 	}
 };
 
+/**
+ * Event handler for mouseOut on the menu panel.
+ */
 ol.control.LayerSwitcher.prototype.onPanelMouseOut = function(e) {
 	e = e || window.event;
     if (this.options.closeOnMouseOut && ( !this.panel.contains(e.toElement || e.relatedTarget)) ) {

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -13,8 +13,8 @@ ol.control.LayerSwitcher = function(opt_options) {
     var tipLabel = this.options.tipLabel ?
       this.options.tipLabel : 'Legend';
     
-    this.options.closeOnMouseOut = this.options.closeOnMouseOut || true;
-    this.options.openOnMouseOver = this.options.openOnMouseOver || true;
+    this.options.closeOnMouseOut = this.options.hasOwnProperty('closeOnMouseOut') ? this.options.closeOnMouseOut : true;
+    this.options.openOnMouseOver = this.options.hasOwnProperty('openOnMouseOver') ? this.options.openOnMouseOver : true;
 
     this.mapListeners = [];
 


### PR DESCRIPTION
- I moved the event handlers into functions, so we can overwrite them.
- Additionally, there are two options to control the behavior upon mouseOver and mouseOut.

Example:

```
var layerSwitcher = new ol.control.LayerSwitcher({
        closeOnMouseOut: false,
        openOnMouseOver: false
});
```

plus this custom style of the button so it never disappears:

```
.layer-switcher.shown button{
        display: block;
}
```
