### PR TITLE
Added checkboxes for parent grouped layers

### DIFF
--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -160,12 +160,26 @@
             });
         }
         if (lyr.getLayers && !lyr.get('combine')){
+            getNestedLayers (lyr, visible);
+        }
+
+        function getNestedLayers (lyr, visible) {
             var lyrs = lyr.getLayers().getArray().slice().reverse();
             for (var i = 0; i < lyrs.length; i++) {
-                var lyr = lyrs[i];
-                var lyrId = lyr.get('id');
+                var l = lyrs[i];
+                var lyrId = l.get('id');
                 var subLyr = document.getElementById(lyrId);
-                subLyr.disabled = !visible;  
+                var disable = true;
+                if (visible) {
+                    disable = false;
+                }
+                subLyr.disabled = disable;
+                if (l.getLayers && !lyr.get('combine')){
+                    if (!subLyr.checked) {
+                        visible = false;
+                    }
+                    getNestedLayers (l, visible);
+                }
             }
         }
     };
@@ -184,7 +198,7 @@
 
         var lyrTitle = lyr.get('title');
         var lyrId = ol.control.LayerSwitcher.uuid();
-        lyr.S.id = lyrId;
+        lyr.set('id', lyrId);
 
         var label = document.createElement('label');
 

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -160,12 +160,14 @@
             });
         }
         if (lyr.getLayers && !lyr.get('combine')){
-            getNestedLayers (lyr, visible);
+            getNestedLayers (lyr);
         }
 
-        function getNestedLayers (lyr, visible) {
+        function getNestedLayers (lyr) {
             var lyrs = lyr.getLayers().getArray().slice().reverse();
+            var lyrN = lyrs.length;
             for (var i = 0; i < lyrs.length; i++) {
+                var lyrvisible = lyr.getVisible();
                 var l = lyrs[i];
                 var lyrId = l.get('id');
                 var subLyr = document.getElementById(lyrId);
@@ -174,11 +176,12 @@
                     disable = false;
                 }
                 subLyr.disabled = disable;
+                if (lyrN == 1){
+                    subLyr.checked = lyrvisible;
+                    l.setVisible(lyrvisible);
+                }
                 if (l.getLayers && !lyr.get('combine')){
-                    if (!subLyr.checked) {
-                        visible = false;
-                    }
-                    getNestedLayers (l, visible);
+                    getNestedLayers (l);
                 }
             }
         }

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -159,6 +159,15 @@
                 }
             });
         }
+        if (lyr.getLayers && !lyr.get('combine')){
+            var lyrs = lyr.getLayers().getArray().slice().reverse();
+            for (var i = 0; i < lyrs.length; i++) {
+                var lyr = lyrs[i];
+                var lyrId = lyr.get('id');
+                var subLyr = document.getElementById(lyrId);
+                subLyr.disabled = !visible;  
+            }
+        }
     };
 
     /**
@@ -175,13 +184,24 @@
 
         var lyrTitle = lyr.get('title');
         var lyrId = ol.control.LayerSwitcher.uuid();
+        lyr.S.id = lyrId;
 
         var label = document.createElement('label');
 
         if (lyr.getLayers && !lyr.get('combine')) {
 
+            var input = document.createElement('input');
+            input.type = 'checkbox';
+            input.id = lyrId;
+            input.checked = lyr.get('visible');
+            input.onchange = function(e) {
+                this_.setVisible_(lyr, e.target.checked);
+            };
+            li.appendChild(input);
+
             li.className = 'group';
             label.innerHTML = lyrTitle;
+            label.htmlFor = lyrId;
             li.appendChild(label);
             var ul = document.createElement('ul');
             li.appendChild(ul);


### PR DESCRIPTION
This bit of code allows the grouped parent layers to be turned on/off. The children layers are grayed-out if the parent layer is disabled. This made a lot of sense in my own map, and hopefully will be useful for others. I tried this code with the @tomchadwin's qgis2web plugin and it seems to work well.


![image](https://user-images.githubusercontent.com/28122345/27881500-1e359d52-6186-11e7-84c9-764166ab5343.png)


