### PR TITLE
WiP: OL2 Design and Behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # OpenLayers 3 LayerSwitcher
 
+This fork tries to mimic the old OL2's [OpenLayers.Control.LayerSwitcher](http://dev.openlayers.org/docs/files/OpenLayers/Control/LayerSwitcher-js.html).
+In particular
+ * the design: sans-serif white font, blue transparent background, - and + button label
+ * the behaviour: click (not hover) of button opens layer list, anoter click closes it
+ * the layer order is not reversed, as it was in OL2.
+
 Grouped layer list control for an OL3 map.
 
 All layers should have a `title` property and base layers should have a `type` property set to `base`. Group layers (`ol.layer.Group`) can be used to visually group layers together. See [examples/layerswitcher.js](examples/layerswitcher.js) for usage.
@@ -8,11 +14,11 @@ All layers should have a `title` property and base layers should have a `type` p
 
 The examples demonstrate usage and can be viewed online thanks to [RawGit](http://rawgit.com/):
 
-* [Basic usage](http://rawgit.com/walkermatt/ol3-layerswitcher/master/examples/layerswitcher.html)
+* [Basic usage](http://rawgit.com/adrelino/ol3-layerswitcher/master/examples/layerswitcher.html)
     * Create a layer switcher control. Each layer to be displayed in the layer switcher has a `title` property as does each Group; each base map layer has a `type: 'base'` property.
-* [Add layer](http://rawgit.com/walkermatt/ol3-layerswitcher/master/examples/addlayer.html)
+* [Add layer](http://rawgit.com/adrelino/ol3-layerswitcher/master/examples/addlayer.html)
     * Add a layer to an existing layer group after the layer switcher has been added to the map.
-* [Scrolling](http://rawgit.com/walkermatt/ol3-layerswitcher/master/examples/scroll.html)
+* [Scrolling](http://rawgit.com/adrelino/ol3-layerswitcher/master/examples/scroll.html)
     * Demonstrate the panel scrolling vertically, control the height of the layer switcher by setting the `max-height` (see [examples/scroll.css](examples/scroll.css)) and it's position relative to the bottom of the map (see the `.layer-switcher.shown` selector in [src/ol3-layerswitcher.css](src/ol3-layerswitcher.css)).
 
 The source for all examples can be found in [examples](examples).

--- a/src/ol3-layerswitcher.css
+++ b/src/ol3-layerswitcher.css
@@ -7,6 +7,7 @@
 }
 
 .layer-switcher {
+    opacity: 0.75;
     position: absolute;
     top: 3.5em;
     right: 0.5em;
@@ -18,11 +19,17 @@
 }
 
 .layer-switcher .panel {
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    width: 250px;
+    font-family: sans-serif;
+    color: white;
     padding: 0 1em 0 0;
     margin: 0;
     border: 4px solid #eee;
     border-radius: 4px;
-    background-color: white;
+    background-color: rgba(0,60,136,0.75);
     display: none;
     max-height: 100%;
     overflow-y: auto;
@@ -34,21 +41,21 @@
 
 .layer-switcher button {
     float: right;
-    width: 38px;
-    height: 38px;
-    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAACE1BMVEX///8A//8AgICA//8AVVVAQID///8rVVVJtttgv98nTmJ2xNgkW1ttyNsmWWZmzNZYxM4gWGgeU2JmzNNr0N1Rwc0eU2VXxdEhV2JqytQeVmMhVmNoydUfVGUgVGQfVGQfVmVqy9hqy9dWw9AfVWRpydVry9YhVmMgVGNUw9BrytchVWRexdGw294gVWQgVmUhVWPd4N6HoaZsy9cfVmQgVGRrytZsy9cgVWQgVWMgVWRsy9YfVWNsy9YgVWVty9YgVWVry9UgVWRsy9Zsy9UfVWRsy9YgVWVty9YgVWRty9Vsy9aM09sgVWRTws/AzM0gVWRtzNYgVWRuy9Zsy9cgVWRGcHxty9bb5ORbxdEgVWRty9bn6OZTws9mydRfxtLX3Nva5eRix9NFcXxOd4JPeINQeIMiVmVUws9Vws9Vw9BXw9BYxNBaxNBbxNBcxdJexdElWWgmWmhjyNRlx9IqXGtoipNpytVqytVryNNrytZsjZUuX210k5t1y9R2zNR3y9V4lp57zth9zdaAnKOGoaeK0NiNpquV09mesrag1tuitbmj1tuj19uktrqr2d2svcCu2d2xwMO63N+7x8nA3uDC3uDFz9DK4eHL4eLN4eIyYnDX5OM5Z3Tb397e4uDf4uHf5uXi5ePi5+Xj5+Xk5+Xm5+Xm6OY6aHXQ19fT4+NfhI1Ww89gx9Nhx9Nsy9ZWw9Dpj2abAAAAWnRSTlMAAQICAwQEBgcIDQ0ODhQZGiAiIyYpKywvNTs+QklPUlNUWWJjaGt0dnd+hIWFh4mNjZCSm6CpsbW2t7nDzNDT1dje5efr7PHy9PT29/j4+Pn5+vr8/f39/f6DPtKwAAABTklEQVR4Xr3QVWPbMBSAUTVFZmZmhhSXMjNvkhwqMzMzMzPDeD+xASvObKePPa+ffHVl8PlsnE0+qPpBuQjVJjno6pZpSKXYl7/bZyFaQxhf98hHDKEppwdWIW1frFnrxSOWHFfWesSEWC6R/P4zOFrix3TzDFLlXRTR8c0fEEJ1/itpo7SVO9Jdr1DVxZ0USyjZsEY5vZfiiAC0UoTGOrm9PZLuRl8X+Dq1HQtoFbJZbv61i+Poblh/97TC7n0neCcK0ETNUrz1/xPHf+DNAW9Ac6t8O8WH3Vp98f5lCaYKAOFZMLyHL4Y0fe319idMNgMMp+zWVSybUed/+/h7I4wRAG1W6XDy4XmjR9HnzvDRZXUAYDFOhC1S/Hh+fIXxen+eO+AKqbs+wAo30zDTDvDxKoJN88sjUzDFAvBzEUGFsnADoIvAJzoh2BZ8sner+Ke/vwECuQAAAABJRU5ErkJggg==') /*logo.png*/;
-    background-repeat: no-repeat;
-    background-position: 2px;
-    background-color: white;
-    border: none;
+    z-index: 1;
+    font-size: x-large;
+    position: absolute;
+    right: 0px;
+    top: 0px;
+    border: 4px solid #eee;
+    border-radius: 4px;
 }
 
 .layer-switcher.shown button {
-    display: none;
+    display: show;
 }
 
 .layer-switcher button:focus, .layer-switcher button:hover {
-    background-color: white;
+
 }
 
 .layer-switcher ul {

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -13,6 +13,8 @@ ol.control.LayerSwitcher = function(opt_options) {
     var tipLabel = options.tipLabel ?
       options.tipLabel : 'Legend';
 
+    this.ol2style = opt_options.ol2style || false;
+
     this.mapListeners = [];
 
     this.hiddenClassName = 'ol-unselectable ol-control layer-switcher';
@@ -26,7 +28,6 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     var button = document.createElement('button');
     button.setAttribute('title', tipLabel);
-    button.innerHTML = "+";
     element.appendChild(button);
 
     this.panel = document.createElement('div');
@@ -36,17 +37,24 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     var this_ = this;
 
-    button.onclick = function(e) {
-        if(button.innerHTML=="+"){
-          this_.showPanel();
-          button.innerHTML="-";
-        }else{
-          this_.hidePanel();
-          button.innerHTML="+";
-        }
+    if(this.ol2style){
+        button.innerHTML = "+";
+        button.onclick = function(e) {
+            if(button.innerHTML=="+"){
+            this_.showPanel();
+            button.innerHTML="-";
+            }else{
+            this_.hidePanel();
+            button.innerHTML="+";
+            }
+        };
+    }else{
+
+    button.onmouseover = function(e) {
+        this_.showPanel();
     };
 
-    /*button.onclick = function(e) {
+    button.onclick = function(e) {
         e = e || window.event;
         this_.showPanel();
         e.preventDefault();
@@ -57,7 +65,8 @@ ol.control.LayerSwitcher = function(opt_options) {
         if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
             this_.hidePanel();
         }
-    };*/
+    };
+    }//end if not ol2style
 
     ol.control.Control.call(this, {
         element: element,
@@ -118,9 +127,11 @@ ol.control.LayerSwitcher.prototype.setMap = function(map) {
     ol.control.Control.prototype.setMap.call(this, map);
     if (map) {
         var this_ = this;
-//         this.mapListeners.push(map.on('pointerdown', function() {
-//             this_.hidePanel();
-//         }));
+        if(!this.ol2style){
+        this.mapListeners.push(map.on('pointerdown', function() {
+            this_.hidePanel();
+        }));
+        }
         this.renderPanel();
     }
 };
@@ -220,7 +231,8 @@ ol.control.LayerSwitcher.prototype.renderLayer_ = function(lyr, idx) {
  * @param {Element} elm DOM element that children will be appended to.
  */
 ol.control.LayerSwitcher.prototype.renderLayers_ = function(lyr, elm) {
-    var lyrs = lyr.getLayers().getArray().slice();//.reverse();
+    var lyrs = lyr.getLayers().getArray().slice();
+    if(!this.ol2style) lyrs = lyrs.reverse();
     for (var i = 0, l; i < lyrs.length; i++) {
         l = lyrs[i];
         if (l.get('title')) {

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -26,6 +26,7 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     var button = document.createElement('button');
     button.setAttribute('title', tipLabel);
+    button.innerHTML = "+";
     element.appendChild(button);
 
     this.panel = document.createElement('div');
@@ -35,11 +36,17 @@ ol.control.LayerSwitcher = function(opt_options) {
 
     var this_ = this;
 
-    button.onmouseover = function(e) {
-        this_.showPanel();
+    button.onclick = function(e) {
+        if(button.innerHTML=="+"){
+          this_.showPanel();
+          button.innerHTML="-";
+        }else{
+          this_.hidePanel();
+          button.innerHTML="+";
+        }
     };
 
-    button.onclick = function(e) {
+    /*button.onclick = function(e) {
         e = e || window.event;
         this_.showPanel();
         e.preventDefault();
@@ -50,7 +57,7 @@ ol.control.LayerSwitcher = function(opt_options) {
         if (!this_.panel.contains(e.toElement || e.relatedTarget)) {
             this_.hidePanel();
         }
-    };
+    };*/
 
     ol.control.Control.call(this, {
         element: element,
@@ -111,9 +118,9 @@ ol.control.LayerSwitcher.prototype.setMap = function(map) {
     ol.control.Control.prototype.setMap.call(this, map);
     if (map) {
         var this_ = this;
-        this.mapListeners.push(map.on('pointerdown', function() {
-            this_.hidePanel();
-        }));
+//         this.mapListeners.push(map.on('pointerdown', function() {
+//             this_.hidePanel();
+//         }));
         this.renderPanel();
     }
 };
@@ -213,7 +220,7 @@ ol.control.LayerSwitcher.prototype.renderLayer_ = function(lyr, idx) {
  * @param {Element} elm DOM element that children will be appended to.
  */
 ol.control.LayerSwitcher.prototype.renderLayers_ = function(lyr, elm) {
-    var lyrs = lyr.getLayers().getArray().slice().reverse();
+    var lyrs = lyr.getLayers().getArray().slice();//.reverse();
     for (var i = 0, l; i < lyrs.length; i++) {
         l = lyrs[i];
         if (l.get('title')) {

--- a/src/ol3-layerswitcher.js
+++ b/src/ol3-layerswitcher.js
@@ -19,7 +19,7 @@
 
         var options = opt_options || {};
 
-        this.ol2style = opt_options.ol2style || false;        
+        this.ol2style = options.ol2style || true;        
 
         var tipLabel = options.tipLabel ?
           options.tipLabel : 'Legend';
@@ -46,6 +46,19 @@
 
         var this_ = this;
 
+    if(this.ol2style){
+            button.innerHTML = "+";
+            button.onclick = function(e) {
+                if(button.innerHTML=="+"){
+                this_.showPanel();
+                button.innerHTML="-";
+                }else{
+                this_.hidePanel();
+                button.innerHTML="+";
+                }
+            };
+        }else{
+    
         button.onmouseover = function(e) {
             this_.showPanel();
         };
@@ -62,27 +75,14 @@
                 this_.hidePanel();
             }
         };
+    }//end if not ol2style
+
 
         ol.control.Control.call(this, {
             element: element,
             target: options.target
         });
 
-    if(this.ol2style){
-        button.innerHTML = "+";
-        button.onclick = function(e) {
-            if(button.innerHTML=="+"){
-            this_.showPanel();
-            button.innerHTML="-";
-            }else{
-            this_.hidePanel();
-            button.innerHTML="+";
-            }
-        };
-    }else{
-
-    button.onmouseover = function(e) {
-        this_.showPanel();
     };
 
     ol.inherits(ol.control.LayerSwitcher, ol.control.Control);
@@ -105,7 +105,6 @@
             this.element.classList.remove(this.shownClassName);
         }
     };
-    }//end if not ol2style
 
     /**
      * Re-draw the layer panel to represent the current state of the layers.
@@ -139,7 +138,7 @@
         if (map) {
             var this_ = this;
             this.mapListeners.push(map.on('pointerdown', function() {
-                (!this.ol2style) && this_.hidePanel();
+                (!this_.ol2style) && this_.hidePanel();
             }));
             this.renderPanel();
         }


### PR DESCRIPTION
This fork tries to mimic the old OL2's [OpenLayers.Control.LayerSwitcher](http://dev.openlayers.org/docs/files/OpenLayers/Control/LayerSwitcher-js.html).
In particular
 * the design: sans-serif white font, blue transparent background, - and + button label
 * the behaviour: click (not hover) on button opens layer list, another click closes it
 * the layer order is not reversed, as it was in OL2.

Here is a screenshot that shows how nicely this design integrates with other common ol plugins:
![layerchooser-ol2style](https://user-images.githubusercontent.com/6432001/30254266-0d92087e-9696-11e7-89a2-d1fa8aa84a82.jpg)

