### PR TITLE
Add option to set main button with a Unicode Decimal Code

### DIFF
--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -25,7 +25,7 @@ export default class LayerSwitcher extends Control {
             options.tipLabel : 'Legend';
 
         var buttonUDCChar = options.buttonUDCChar ?
-            options.buttonUDCChar : '9776'
+            options.buttonUDCChar : '';
 
         var element = document.createElement('div');
 

--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -47,7 +47,7 @@ export default class LayerSwitcher extends Control {
         button.setAttribute('class', 'layer-switcher-open-main')
         button.setAttribute('type', 'button');
         button.setAttribute('title', tipLabel);
-        if (buttonUDCChar!=='') buttonbutton.innerHTML = String.fromCharCode(buttonUDCChar);
+        if (buttonUDCChar!=='') button.innerHTML = String.fromCharCode(buttonUDCChar);
         element.appendChild(button);
 
         this.panel = document.createElement('div');

--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -47,7 +47,7 @@ export default class LayerSwitcher extends Control {
         button.setAttribute('class', 'layer-switcher-open-main')
         button.setAttribute('type', 'button');
         button.setAttribute('title', tipLabel);
-        button.innerHTML = String.fromCharCode(buttonUDCChar);
+        if (buttonUDCChar!=='') buttonbutton.innerHTML = String.fromCharCode(buttonUDCChar);
         element.appendChild(button);
 
         this.panel = document.createElement('div');

--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -47,7 +47,7 @@ export default class LayerSwitcher extends Control {
         button.setAttribute('class', 'layer-switcher-open-main')
         button.setAttribute('type', 'button');
         button.setAttribute('title', tipLabel);
-        if (buttonUDCChar!=='') button.innerHTML = String.fromCharCode(buttonUDCChar);
+        if (buttonUDCChar !== '') button.innerHTML = String.fromCharCode(buttonUDCChar);
         element.appendChild(button);
 
         this.panel = document.createElement('div');

--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -10,6 +10,7 @@ var CSS_PREFIX = 'layer-switcher-';
  * @extends {ol/control/Control~Control}
  * @param {Object} opt_options Control options, extends ol/control/Control~Control#options adding:
  * @param {String} opt_options.tipLabel the button tooltip.
+ * @param {String} opt_options.buttonUDCChar the button Unicode Decimal Character Code.
  * @param {String} opt_options.groupSelectStyle either `'none'` - groups don't get a checkbox,
  *   `'children'` (default) groups have a checkbox and affect child visibility or
  *   `'group'` groups have a checkbox but do not alter child visibility (like QGIS).
@@ -22,6 +23,9 @@ export default class LayerSwitcher extends Control {
 
         var tipLabel = options.tipLabel ?
             options.tipLabel : 'Legend';
+
+        var buttonUDCChar = options.buttonUDCChar ?
+            options.buttonUDCChar : '9776'
 
         var element = document.createElement('div');
 
@@ -40,7 +44,10 @@ export default class LayerSwitcher extends Control {
         element.className = this.hiddenClassName;
 
         var button = document.createElement('button');
+        button.setAttribute('class', 'layer-switcher-open-main')
+        button.setAttribute('type', 'button');
         button.setAttribute('title', tipLabel);
+        button.innerHTML = String.fromCharCode(buttonUDCChar);
         element.appendChild(button);
 
         this.panel = document.createElement('div');


### PR DESCRIPTION
Hello,

As I want to keep main ol-layerswitcher button as OL buttons style : 

1 - I have to change background color for ol-layerswitcher main button
2 - I have to remove background-image only for ol-layerswitcher main button, not for the underneath panel.
3 - I have to replace background image with a simple character , I have choosen [this](https://www.codetable.net/decimal/9776) for the moment.

So I have done those things : 
- create a CSS class for ol-layerswitcher main button, this way, color and background-image may be set without interfering with underneath panel.
- add an option to ol-layerswitcher control to gives the unicode decimal value of the desired character. If  option buttonUDCChar is not set or no character is given then it fallback on actual CSS background-image. 

In your inline CSS - disable background image and set color to OL controls button standard:

```
button.layer-switcher-open-main {
  background-image: none !important; //removed only for main button
  background-color: rgba(0, 60, 136, 0.5) !important; // color set only for main button
}
```

Gives optional character when create the LayerSwitcher : 
```
var mLayerSwitcher = new LayerSwitcher({
                tipLabel: 'Légende', 
                buttonUDCChar: '9776' // hamburger UDC value
            })
```

maybe this may help someone.

Thanks,

Eric

PS :  I have also add type to main button (https://developer.mozilla.org/fr/docs/Web/HTML/Element/Button)