### PR TITLE
Activation mode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ See [the examples](./examples) for usage.
 **Parameters**
 
 -   `opt_options` **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** Control options, extends ol/control/Control~Control#options adding:
+    -   `opt_options.activationMode` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Event to use on the button to collapse or expand the panel.
+          `'mouseover'` (default) the layerswitcher panel stays expanded while button or panel are hovered. 
+          `'click'` a click on the button toggles the layerswitcher visibility.
+    -   `opt_options.collapseLabel` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Text label to use for the expanded layerswitcher button. E.g.:
+          `'»'` (default) or `'\u00BB'`, `'-'` or `'\u2212'`. Not visible if activation mode is `'mouseover'`
+    -   `opt_options.label` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** Text label to use for the collapsed layerswitcher button. E.g.:
+          `''` (default), `'«'` or `'\u00AB'`, `'+'`.
     -   `opt_options.tipLabel` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** the button tooltip.
     -   `opt_options.groupSelectStyle` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** either `'none'` - groups don't get a checkbox,
           `'children'` (default) groups have a checkbox and affect child visibility or

--- a/examples/activation-mode-click.html
+++ b/examples/activation-mode-click.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>OpenLayers - LayerSwitcher</title>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no, width=device-width">
+    <link rel="stylesheet" href="https://openlayers.org/en/v6.1.1/css/ol.css" />
+    <link rel="stylesheet" href="../src/ol-layerswitcher.css" />
+    <link rel="stylesheet" href="layerswitcher.css" />
+  </head>
+  <body>
+    <div id="map"></div>
+    <!-- The line below is only needed for old environments like Internet Explorer and Android 4.x -->
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=requestAnimationFrame,Element.prototype.classList,URL"></script>
+    <script src="https://openlayers.org/en/v6.1.1/build/ol.js"></script>
+    <script src="../dist/ol-layerswitcher.js"></script>
+    <script src="activation-mode-click.js"></script>
+  </body>
+</html>

--- a/examples/activation-mode-click.js
+++ b/examples/activation-mode-click.js
@@ -1,0 +1,111 @@
+(function() {
+    var map = new ol.Map({
+        target: 'map',
+        layers: [
+            new ol.layer.Group({
+                // A layer must have a title to appear in the layerswitcher
+                'title': 'Base maps',
+                layers: [
+                    new ol.layer.Group({
+                        // A layer must have a title to appear in the layerswitcher
+                        title: 'Water color with labels',
+                        // Setting the layers type to 'base' results
+                        // in it having a radio button and only one
+                        // base layer being visibile at a time
+                        type: 'base',
+                        // Setting combine to true causes sub-layers to be hidden
+                        // in the layerswitcher, only the parent is shown
+                        combine: true,
+                        visible: false,
+                        layers: [
+                            new ol.layer.Tile({
+                                source: new ol.source.Stamen({
+                                    layer: 'watercolor'
+                                })
+                            }),
+                            new ol.layer.Tile({
+                                source: new ol.source.Stamen({
+                                    layer: 'terrain-labels'
+                                })
+                            })
+                        ]
+                    }),
+                    new ol.layer.Tile({
+                        // A layer must have a title to appear in the layerswitcher
+                        title: 'Water color',
+                        // Again set this layer as a base layer
+                        type: 'base',
+                        visible: false,
+                        source: new ol.source.Stamen({
+                            layer: 'watercolor'
+                        })
+                    }),
+                    new ol.layer.Tile({
+                        // A layer must have a title to appear in the layerswitcher
+                        title: 'OSM',
+                        // Again set this layer as a base layer
+                        type: 'base',
+                        visible: true,
+                        source: new ol.source.OSM()
+                    })
+                ]
+            }),
+            new ol.layer.Group({
+                // A layer must have a title to appear in the layerswitcher
+                title: 'Overlays',
+                // Adding a 'fold' property set to either 'open' or 'close' makes the group layer
+                // collapsible
+                fold: 'open',
+                layers: [
+                    new ol.layer.Image({
+                        // A layer must have a title to appear in the layerswitcher
+                        title: 'Countries',
+                        source: new ol.source.ImageArcGISRest({
+                            ratio: 1,
+                            params: {'LAYERS': 'show:0'},
+                            url: "https://ons-inspire.esriuk.com/arcgis/rest/services/Administrative_Boundaries/Countries_December_2016_Boundaries/MapServer"
+                        })
+                    }),
+                    new ol.layer.Group({
+                        // A layer must have a title to appear in the layerswitcher
+                        title: 'Census',
+                        fold: 'open',
+                        layers: [
+                            new ol.layer.Image({
+                                // A layer must have a title to appear in the layerswitcher
+                                title: 'Districts',
+                                source: new ol.source.ImageArcGISRest({
+                                    ratio: 1,
+                                    params: {'LAYERS': 'show:0'},
+                                    url: "https://ons-inspire.esriuk.com/arcgis/rest/services/Census_Boundaries/Census_Merged_Local_Authority_Districts_December_2011_Boundaries/MapServer"
+                                })
+                            }),
+                            new ol.layer.Image({
+                                // A layer must have a title to appear in the layerswitcher
+                                title: 'Wards',
+                                visible: false,
+                                source: new ol.source.ImageArcGISRest({
+                                    ratio: 1,
+                                    params: {'LAYERS': 'show:0'},
+                                    url: "https://ons-inspire.esriuk.com/arcgis/rest/services/Census_Boundaries/Census_Merged_Wards_December_2011_Boundaries/MapServer"
+                                })
+                            })
+                        ]
+                    })
+                ]
+            })
+        ],
+        view: new ol.View({
+            center: ol.proj.transform([-0.92, 52.96], 'EPSG:4326', 'EPSG:3857'),
+            zoom: 6
+        })
+    });
+
+    var layerSwitcher = new ol.control.LayerSwitcher({
+        activationMode: 'click',
+        tipLabel: 'Légende', // Optional label for button
+        groupSelectStyle: 'children' // Can be 'children' [default], 'group' or 'none'
+    });
+    map.addControl(layerSwitcher);
+
+})();

--- a/src/ol-layerswitcher.css
+++ b/src/ol-layerswitcher.css
@@ -47,6 +47,14 @@
     display: none;
 }
 
+.layer-switcher.shown.activationModeClick > button {
+    display: block;
+    background-image: unset;
+    color: black;
+    right: 2px;
+    position: absolute;
+}
+
 .layer-switcher button:focus, .layer-switcher button:hover {
     background-color: white;
 }


### PR DESCRIPTION
Adds the activationMode 'click'/'mouseover' option.

Its necessity was discussed in many issues already.

The defaults are set so that nothing changes the current behavior, just have a look at the `examples/layerswitcher.js` where I added an option to the top to switch between the two different modes.