### PR TITLE
removed unused "key" from setMap

### DIFF
--- a/src/ol-layerswitcher.js
+++ b/src/ol-layerswitcher.js
@@ -109,7 +109,7 @@ export default class LayerSwitcher extends Control {
     */
     setMap(map) {
         // Clean up listeners associated with the previous map
-        for (var i = 0, key; i < this.mapListeners.length; i++) {
+        for (var i = 0; i < this.mapListeners.length; i++) {
             unByKey(this.mapListeners[i]);
         }
         this.mapListeners.length = 0;


### PR DESCRIPTION
There is a "key" variable that is never used and can be deleted.