### PR TITLE
Check layer MinZoom and MaxZoom if supported

### DIFF
--- a/src/ol-layerswitcher.ts
+++ b/src/ol-layerswitcher.ts
@@ -570,8 +570,13 @@ export default class LayerSwitcher extends Control {
       label.innerHTML = lyrTitle;
 
       const rsl = map.getView().getResolution();
-      if (rsl > lyr.getMaxResolution() || rsl < lyr.getMinResolution()) {
+      if (rsl >= lyr.getMaxResolution() || rsl < lyr.getMinResolution()) {
         label.className += ' disabled';
+      } else if (lyr.getMinZoom && lyr.getMaxZoom) {
+        const zoom =  map.getView().getZoom();
+        if (zoom <= lyr.getMinZoom() || zoom > lyr.getMaxZoom()) {
+          label.className += ' disabled';
+        }
       }
 
       li.appendChild(label);


### PR DESCRIPTION
Adds a backward compatible check for layer `mInZoom` and `maxZoom` visibility where the OpenLayers build supports it.  Also fixes the inclusivity/exclusivity of the existing resolution check,  Based on the `inView` function in https://github.com/openlayers/openlayers/blob/main/src/ol/layer/Layer.js  Fixes #404