### PR TITLE
Scroll vertically if required by default

### DIFF
--- a/dist/ol-layerswitcher.css
+++ b/dist/ol-layerswitcher.css
@@ -35,9 +35,14 @@
 .layer-switcher button:hover {
   background-color: white;
 }
+
 .layer-switcher.shown {
   overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100% - 5.5em);
 }
+
 .layer-switcher.shown.ol-control {
   background-color: transparent;
 }

--- a/examples/scroll.css
+++ b/examples/scroll.css
@@ -1,4 +1,4 @@
-/* Set a small height to demonstrate the layer switcher scrolling */
+/* Set a small height to demonstrate the layer switcher automatically scrolling when needed */
 #map {
   max-height: 300px;
 }

--- a/examples/scroll.css
+++ b/examples/scroll.css
@@ -1,4 +1,11 @@
-/* Set the maxmimum height of the layerswitcher when it's shown */
-.layer-switcher.shown {
-  max-height: 170px;
+/* Set a small height to demonstrate the layer switcher scrolling */
+#map {
+  max-height: 300px;
+}
+
+/* Fixed max-height for IE11 to support scrolling, due to incomplete support for flexbox */
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  .layer-switcher.shown {
+    max-height: 170px;
+  }
 }

--- a/examples/scroll.js
+++ b/examples/scroll.js
@@ -104,5 +104,9 @@
     })
   });
 
-  map.addControl(new ol.control.LayerSwitcher());
+  map.addControl(
+    new ol.control.LayerSwitcher({
+      activationMode: 'click'
+    })
+  );
 })();

--- a/src/ol-layerswitcher.css
+++ b/src/ol-layerswitcher.css
@@ -35,9 +35,14 @@
 .layer-switcher button:hover {
   background-color: white;
 }
+
 .layer-switcher.shown {
   overflow-y: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100% - 5.5em);
 }
+
 .layer-switcher.shown.ol-control {
   background-color: transparent;
 }


### PR DESCRIPTION
As per #475 implement @devsupportman's suggestion to allow the control to grow vertically until it would overflow the map, at which point a vertical scroll bar is present.